### PR TITLE
Update VauxhallOpel-Ampera generations: added Wikipedia references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
-# Model make
+# Vauxhall/Opel Ampera
+
+This repository contains signal set configurations for the Vauxhall/Opel Ampera, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Vauxhall/Opel Ampera.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.
 

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,7 @@
+references:
+  - "https://en.wikipedia.org/wiki/Chevrolet_Volt"
+  - "https://en.wikipedia.org/wiki/Chevrolet_Bolt"
+
 generations:
   - name: "First Generation"
     start_year: 2011


### PR DESCRIPTION
- Added references section with Chevrolet Volt and Chevrolet Bolt Wikipedia URLs
- Confirmed generation data (2011-2015, 2017-2019) matches Wikipedia information
- Updated README.md with standard vehicle template

Wikipedia sources confirm:
- First generation Ampera (2011-2015) was European variant of Chevrolet Volt
- Second generation Ampera-e (2017-2019) was European variant of Chevrolet Bolt EV
